### PR TITLE
8.56 forced hiera lookup in params, adjust text_props

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class io_portalwar::params {
   $favicons                  = false
   $text_properties           = false
   $redirect_target           = './ps/signon.html'
-  $pia_domain_list           = undef
+  $pia_domain_list           = hiera_hash('pia_domain_list')
   $pia_cookie_name           = undef
   $configprop                = undef
   $psserver_list             = undef

--- a/manifests/text_properties.pp
+++ b/manifests/text_properties.pp
@@ -17,11 +17,11 @@ class io_portalwar::text_properties (
   $pia_domain_list.each |$domain_name, $pia_domain_info| {
     $ps_cfg_home_dir = $pia_domain_info['ps_cfg_home_dir']
 
-    $properties = $text_properties[$domain_name]
     $site_list   = $pia_domain_info['site_list']
     $site_list.each |$site_name, $site_info| {
 
         $config   = "${ps_cfg_home_dir}/webserv/${domain_name}/applications/peoplesoft/PORTAL.war/WEB-INF/psftdocs/${site_name}/text.properties"
+        $properties = $text_properties[$domain_name][$site_name]
         $properties.each | $setting, $value | {
 
           ini_setting { "${domain_name}, ${site_name} ${setting} ${value}" :


### PR DESCRIPTION
- Starting in 8.56, the `pia_domain_list` was just defaulting as `undef`. Added a `hiera_hash` lookup in the `params.pp` default section
- The `text.properties` code wasn't look for site specific hash. Adjusted for that.