### PR TITLE
Remove PSEMHUB web module from PIA (CVE-2026-35273)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
     - [Health Check File](#health-check-file)
     - [Host Information File](#host-information-file)
     - [robots.txt](#robotstxt-file)
+    - [Remove PSEMHUB](#remove-psemhub)
 
 ## Description
 
@@ -141,3 +142,47 @@ You can deploy a robots.txt that will stop search indexes from crawling your Peo
 ```yaml
 io_portalwar::robots: true
 ```
+### Remove PSEMHUB
+
+Removes the Environment Management Hub (`PSEMHUB`) web module from the
+deployed PeopleSoft EAR. This implements Oracle's documented fix for
+**CVE-2026-35273** (Oracle Security Alert, June 2026 — CVSS 9.8,
+remotely exploitable without authentication, component: PeopleTools
+Updates - Environment Management, affecting 8.61 and 8.62) for single
+server PIA domains:
+
+1. Removes the `PSEMHUB` `<module>` entry from
+   `applications/peoplesoft/META-INF/application.xml`
+2. Removes the exploded `applications/peoplesoft/PSEMHUB.war` folder
+
+```yaml
+io_portalwar::remove_psemhub: true
+```
+
+Notes:
+
+* Linux, single server PIA domains only. For multi-server domains with
+  a dedicated `PSEMHUB` managed server, stop/disable that managed
+  server instead of using this feature.
+* A PIA bounce is required for the change to take effect on a running
+  domain: stop PIA, run Puppet, start PIA.
+* PIA redeploys and PeopleTools patches will restore `PSEMHUB`.
+  Re-running with this flag set re-removes it, which is what makes the
+  mitigation DPK-durable.
+* EMF is only used by Change Assistant/PUM crawl-and-apply cycles.
+  Leave this feature disabled on the environment you actually run
+  Change Assistant against, and remove the hub everywhere else.
+
+To apply ad hoc without a full DPK run:
+
+```bash
+$PS_CFG_HOME/webserv/<domain>/bin/stopPIA.sh
+
+puppet apply --confdir $DPK_HOME/puppet \
+  -e "class { '::io_portalwar': remove_psemhub => true }"
+
+$PS_CFG_HOME/webserv/<domain>/bin/startPIA.sh
+```
+
+Declare the parent class (not `io_portalwar::psemhub` alone) so
+`pia_domain_list` and related values resolve from hiera.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,7 @@ class io_portalwar (
   $healthcheck               = $::io_portalwar::params::healthcheck,
   $hostinfo                  = $::io_portalwar::params::hostinfo,
   $robots                    = $::io_portalwar::params::robots,
+  $remove_psemhub            = $::io_portalwar::params::remove_psemhub,
 ) inherits ::io_portalwar::params {
 
   validate_hash($pia_domain_list)
@@ -63,5 +64,9 @@ class io_portalwar (
 
     if ($robots) {
     contain ::io_portalwar::robots
+  }
+
+  if ($remove_psemhub) {
+    contain ::io_portalwar::psemhub
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,7 @@ class io_portalwar::params {
   $healthcheck               = undef
   $hostinfo                  = undef
   $robots                    = undef
+  $remove_psemhub            = undef
 
   case $::osfamily {
     'AIX':     {

--- a/manifests/psemhub.pp
+++ b/manifests/psemhub.pp
@@ -1,0 +1,66 @@
+# io_portalwar::psemhub
+#
+# Remove the PSEMHUB (Environment Management Hub) web module from the
+# deployed PeopleSoft EAR. Mitigation for CVE-2026-35273 (Oracle Security
+# Alert, June 2026) per Oracle's documented fix for single server domains:
+#
+#   1. Remove the PSEMHUB <module> entry from META-INF/application.xml
+#   2. Remove the exploded PSEMHUB.war folder
+#
+# Notes:
+#   - Linux only. Single server PIA domains only. For multi-server domains
+#     with a dedicated PSEMHUB managed server, stop/disable that server
+#     instead.
+#   - A PIA bounce is required for a running domain to pick this up
+#     (stop -> puppet apply -> start). During full DPK provisioning,
+#     ensure this runs before domain boot.
+#   - Re-running after a PIA redeploy/tools patch re-removes the hub,
+#     which is the point: this makes the mitigation DPK-durable.
+#
+# @example psft_customizations.yaml settings
+#   ---
+#   # Enable this class (io_portalwar/init.pp contains it when true)
+#   remove_psemhub: true
+#
+# @example Run this manifest directly with puppet apply (as root)
+#   # DPK_HOME is your DPK base, e.g. /opt/oracle/psft/dpk
+#   $PS_CFG_HOME/webserv/<domain>/bin/stopPIA.sh
+#
+#   puppet apply --confdir $DPK_HOME/puppet \
+#     -e "class { '::io_portalwar': remove_psemhub => true }"
+#
+#   $PS_CFG_HOME/webserv/<domain>/bin/startPIA.sh
+#
+#   # If remove_psemhub: true is already set in psft_customizations.yaml,
+#   # the -e payload can simply be: 'include ::io_portalwar'
+#   # Note: declare the parent class (not the subclass alone) so
+#   # pia_domain_list and friends resolve from hiera.
+class io_portalwar::psemhub (
+  $ensure          = 'absent',
+  $pia_domain_list = $io_portalwar::pia_domain_list,
+) {
+
+  $pia_domain_list.each |$domain_name, $pia_domain_info| {
+
+    $ps_cfg_home_dir = $pia_domain_info['ps_cfg_home_dir']
+    $ear_dir         = "${ps_cfg_home_dir}/webserv/${domain_name}/applications/peoplesoft"
+    $app_xml         = "${ear_dir}/META-INF/application.xml"
+
+    augeas { "${domain_name} remove PSEMHUB from application.xml" :
+      lens    => 'Xml.lns',
+      incl    => $app_xml,
+      context => "/files${app_xml}/application",
+      changes => "rm module[web/web-uri/#text='PSEMHUB.war']",
+      onlyif  => "match module[web/web-uri/#text='PSEMHUB.war'] size > 0",
+    }
+
+    file { "${ear_dir}/PSEMHUB.war" :
+      ensure  => $ensure,
+      force   => true,
+      backup  => false,
+      require => Augeas["${domain_name} remove PSEMHUB from application.xml"],
+    }
+
+  } # end pia_domain_list
+
+}

--- a/manifests/psemhub.pp
+++ b/manifests/psemhub.pp
@@ -20,7 +20,7 @@
 # @example psft_customizations.yaml settings
 #   ---
 #   # Enable this class (io_portalwar/init.pp contains it when true)
-#   remove_psemhub: true
+#   io_portalwar::remove_psemhub: true
 #
 # @example Run this manifest directly with puppet apply (as root)
 #   # DPK_HOME is your DPK base, e.g. /opt/oracle/psft/dpk
@@ -31,7 +31,7 @@
 #
 #   $PS_CFG_HOME/webserv/<domain>/bin/startPIA.sh
 #
-#   # If remove_psemhub: true is already set in psft_customizations.yaml,
+#   # If io_portalwar::remove_psemhub: true is already set in psft_customizations.yaml,
 #   # the -e payload can simply be: 'include ::io_portalwar'
 #   # Note: declare the parent class (not the subclass alone) so
 #   # pia_domain_list and friends resolve from hiera.

--- a/manifests/psemhub.pp
+++ b/manifests/psemhub.pp
@@ -38,7 +38,7 @@
 class io_portalwar::psemhub (
   $ensure          = 'absent',
   $pia_domain_list = $io_portalwar::pia_domain_list,
-) {
+) inherits io_portalwar {
 
   $pia_domain_list.each |$domain_name, $pia_domain_info| {
 


### PR DESCRIPTION
## What

Adds an `io_portalwar::remove_psemhub` feature that strips the Environment Management Hub (`PSEMHUB`) web module from the deployed PeopleSoft PIA EAR, as a mitigation for **CVE-2026-35273** (unauthenticated remote code execution via the PeopleTools Environment Management component, CVSS 9.8). Builds on the existing `psemhub` branch (#54) and adds the missing class wiring so the feature actually takes effect.

## Why

`manifests/psemhub.pp` implemented the removal logic (drop the `PSEMHUB.war` `<module>` from `META-INF/application.xml` via Augeas + remove the exploded war dir), but the `remove_psemhub` toggle was never declared on the `io_portalwar` class. As a result `io_portalwar::remove_psemhub: true` — and the README `puppet apply -e` one-liner — were no-ops.

## Changes

- **`params.pp`** — add `$remove_psemhub` default (`undef`).
- **`init.pp`** — declare the `$remove_psemhub` parameter and conditionally `contain ::io_portalwar::psemhub`, matching the existing feature-flag pattern (`robots` / `healthcheck` / `hostinfo`).
- **`psemhub.pp`** — `inherits io_portalwar` so `pia_domain_list` resolves when the subclass is declared on its own.

## Scope / notes

- Linux, single-server PIA domains. For multi-server domains with a dedicated `PSEMHUB` managed server, stop/disable that server instead.
- Because `io_portalwar` is contained before domain boot in a typical role chain, a full DPK run strips the module before PIA starts — no separate bounce. On an already-running domain, the documented stop → `puppet apply -e` → start applies.
- The mitigation is DPK-durable: a PIA redeploy or tools patch restores `PSEMHUB`, and the next run with the flag set re-removes it.

## Testing

Validate against a PT 8.62 single-server PIA domain: with the flag set, confirm the `PSEMHUB.war` `<module>` entry is gone from `application.xml`, the exploded war dir is removed, `/PSEMHUB/` returns 404, and normal `/ps/` signon is unaffected. Recommend a quick check that Augeas `Xml.lns` parses the target's actual `application.xml` before relying on it.

Closes #54.